### PR TITLE
Modified GraphQL arguments ('first' and 'order')

### DIFF
--- a/src/comments/comment-list.js
+++ b/src/comments/comment-list.js
@@ -10,7 +10,7 @@ import CommentForm from '../comments/comment-form';
 // Create a GraphQL query for the comment list.
 const commentQuery = gql`
 query($postId: ID!) {
-    comments(first: 1000, where: { contentId: $postId, contentStatus: PUBLISH, orderby: COMMENT_DATE, order: ASC }) {
+    comments(first: 100, where: { contentId: $postId, contentStatus: PUBLISH, orderby: COMMENT_DATE, order: DESC }) {
       nodes {
           ...CommentFields
       }


### PR DESCRIPTION
Modified GraphQL argument to only request the first 100 items (vs. previously 1000 - which is not possible with the current version of gatsby-source-wordpress).  Changed comment sorting argument from ASC to DESC, in order to show newest comments first).